### PR TITLE
Add macos github runner to print-devices ci and ensure visionOS simulator is supported in the future.

### DIFF
--- a/.github/workflows/print-devices.yml
+++ b/.github/workflows/print-devices.yml
@@ -14,6 +14,7 @@ jobs:
           - macos-11
           - macos-12
           - macos-13
+          - macos-14
           - macos-latest
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
I actually wanted to make sure this github action supported the Apple Vision Pro simulator which runs on the macOS-14 (arm) runner. If I read the source correctly, it would support the apple vision pro but requires the xcode used in CI to be changed, it's just not in the README (I can add this if you'd like).

Recently, the macOS-latest runner moved to macOS-14. This PR makes it explicit. Also, I think that when the github runner image starts using xcode 15.2 or later, visionOS will just appear on the wiki page for this.